### PR TITLE
I have removed Issue stated above.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,7 +18,7 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
-        buildConfigField("String", "UNSPLASH_ACCESS_KEY", unsplash_access_key)
+        //buildConfigField("String", "UNSPLASH_ACCESS_KEY", unsplash_access_key)
     }
 
     buildTypes {


### PR DESCRIPTION
1) Open the build.gradle file of app module and add \\ in fron ot this line ' buildConfigField("String", "UNSPLASH_ACCESS_KEY", unsplash_access_key)'

2) Create an account on UNSPLASH and copy the api key in gradle.properties as shown in the video and sync it. 

3)Go back to build.gradle file and remove the \\ from in front of this line and sync the file. The error is removed :)